### PR TITLE
fix: change slot recipe raw function typings

### DIFF
--- a/packages/types/src/recipe.ts
+++ b/packages/types/src/recipe.ts
@@ -123,7 +123,7 @@ export type SlotRecipeVariantFn<S extends string, T extends RecipeVariantRecord>
 
 export interface SlotRecipeRuntimeFn<S extends string, T extends SlotRecipeVariantRecord<S>>
   extends SlotRecipeVariantFn<S, T> {
-  raw: (props?: RecipeSelection<T>) => Record<S, SystemStyleObject>
+  raw: (props?: RecipeSelection<T>) => RecipeSelection<T>
   variantKeys: (keyof T)[]
   variantMap: RecipeVariantMap<T>
   splitVariantProps<Props extends RecipeSelection<T>>(


### PR DESCRIPTION
## 📝 Description

`SlotRecipeRuntimeFn`'s `raw()` function uses a return type that seems unnecessary to be different from the props' type; especially since the respective js generated (as seen in generator artifacts) is simply just `raw: (props) => props`. Correcting this would make working with slot recipe types easier as you can map the generic types to the actual slot recipe types that are being generated.

## ⛳️ Current behavior (updates)

The generic SlotRecipeRuntimeFn's `raw()` return type is `Record<S, SystemStyleObject>` which is not a proper match to `RecipeSelection<T>`

## 🚀 New behavior

Return type uses the `RecipeSelection<T>`.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
